### PR TITLE
fix piping to non-file streams

### DIFF
--- a/lib/zip.js
+++ b/lib/zip.js
@@ -50,7 +50,7 @@ function Zip(output) {
     }
     zip.emit("error", error);
   });
-  output.on("close", function() {
+  output.on("finish", function() {
     debug("Zip completed");
     zip.emit("end");
   });


### PR DESCRIPTION
"close" isn't part of the Writable interface, but is actually fired by
file streams specifically. This means that `pipe()`ing into some
non-file backed Writable stream will never cause the passes `end` event
to be fired